### PR TITLE
Implement issuer and verifier registry

### DIFF
--- a/contracts/infra-did-registry/include/infra-did-registry.hpp
+++ b/contracts/infra-did-registry/include/infra-did-registry.hpp
@@ -89,6 +89,25 @@ namespace infra_did {
          [[eosio::action]]
          void pkdidrmvrvkd( const uint64_t pkid );
 
+         /**
+          * [Public Key DID] register did as trusted
+          *
+          * @param ram_payer
+          * @param pk
+          * @param metadata
+          */
+         [[eosio::action]]
+         void pkaddtrusted(const name& ram_payer, const public_key& pk, const string& metadata);
+
+         /**
+          * [Public Key DID] deregister did as trusted
+          *
+          * @param ram_payer
+          * @param pk
+          */
+         [[eosio::action]]
+         void pkrmtrusted(const name& ram_payer, const public_key& pk);
+
       private:
 
          checksum256 pksetattr_sig_digest( const public_key& pk, const uint16_t nonce, const string& key, const string& value );

--- a/contracts/infra-did-registry/include/infra-did-registry.hpp
+++ b/contracts/infra-did-registry/include/infra-did-registry.hpp
@@ -146,6 +146,22 @@ namespace infra_did {
 
          typedef eosio::multi_index< "pkdidowner"_n, pub_key_did_owner > pub_key_did_owner_table;
 
+         struct [[eosio::table]] trusted_did {
+            uint64_t id; // unique identifier
+            public_key pk;  // only supports ecc_public_key(secp256k1, secp256r1) (33 bytes compressed key format)
+            string metadata; // metadata for the DID, stringified JSON
+            
+            uint64_t primary_key() const { return id; }
+            checksum256 by_pk() const { return get_pubkey_index_value(pk); } // secondary index for public key
+
+            EOSLIB_SERIALIZE( trusted_did, (id)(pk)(metadata) )
+         };
+
+         typedef eosio::multi_index< "trusteddid"_n, 
+            trusted_did,
+            indexed_by<"bypk"_n, const_mem_fun<trusted_did, checksum256, &trusted_did::by_pk>>
+         > trusted_did_table;
+
          struct [[eosio::table("global")]] global_state {
             global_state() { }
             uint64_t next_pkid;

--- a/contracts/infra-did-registry/include/infra-did-registry.hpp
+++ b/contracts/infra-did-registry/include/infra-did-registry.hpp
@@ -165,6 +165,7 @@ namespace infra_did {
 
          typedef eosio::multi_index< "pkdidowner"_n, pub_key_did_owner > pub_key_did_owner_table;
 
+         // authorizer account can add trusted DID in trusted_did table with scope as authorizer account name
          struct [[eosio::table]] trusted_did {
             uint64_t id; // unique identifier
             public_key pk;  // only supports ecc_public_key(secp256k1, secp256r1) (33 bytes compressed key format)

--- a/contracts/infra-did-registry/include/infra-did-registry.hpp
+++ b/contracts/infra-did-registry/include/infra-did-registry.hpp
@@ -90,23 +90,33 @@ namespace infra_did {
          void pkdidrmvrvkd( const uint64_t pkid );
 
          /**
-          * [Public Key DID] register did as trusted
+          * [Public Key DID] register did as authorized
           *
-          * @param ram_payer
+          * @param authorizer
           * @param pk
-          * @param metadata
+          * @param properties
           */
          [[eosio::action]]
-         void pkaddtrusted(const name& ram_payer, const public_key& pk, const string& metadata);
+         void pkauthreg(const name& authorizer, const public_key& pk, const string& properties);
 
          /**
-          * [Public Key DID] deregister did as trusted
+          * [Public Key DID] update properties of authorized did
           *
-          * @param ram_payer
+          * @param authorizer
+          * @param pk
+          * @param properties
+          */
+         [[eosio::action]]
+         void pkauthupdate(const name& authorizer, const public_key& pk, const string& properties);
+
+         /**
+          * [Public Key DID] deregister did as authorized
+          *
+          * @param authorizer
           * @param pk
           */
          [[eosio::action]]
-         void pkrmtrusted(const name& ram_payer, const public_key& pk);
+         void pkauthremove(const name& authorizer, const public_key& pk);
 
       private:
 
@@ -165,22 +175,22 @@ namespace infra_did {
 
          typedef eosio::multi_index< "pkdidowner"_n, pub_key_did_owner > pub_key_did_owner_table;
 
-         // authorizer account can add trusted DID in trusted_did table with scope as authorizer account name
-         struct [[eosio::table]] trusted_did {
+         // authorizer account can add authorized DID in authorized_pub_key_did table with scope as authorizer account name
+         struct [[eosio::table]] authorized_pub_key_did {
             uint64_t id; // unique identifier
             public_key pk;  // only supports ecc_public_key(secp256k1, secp256r1) (33 bytes compressed key format)
-            string metadata; // metadata for the DID, stringified JSON
+            string properties; // properties for the DID, stringified JSON
             
             uint64_t primary_key() const { return id; }
             checksum256 by_pk() const { return get_pubkey_index_value(pk); } // secondary index for public key
 
-            EOSLIB_SERIALIZE( trusted_did, (id)(pk)(metadata) )
+            EOSLIB_SERIALIZE( authorized_pub_key_did, (id)(pk)(properties) )
          };
 
-         typedef eosio::multi_index< "trusteddid"_n, 
-            trusted_did,
-            indexed_by<"bypk"_n, const_mem_fun<trusted_did, checksum256, &trusted_did::by_pk>>
-         > trusted_did_table;
+         typedef eosio::multi_index< "authpkdid"_n, 
+            authorized_pub_key_did,
+            indexed_by<"bypk"_n, const_mem_fun<authorized_pub_key_did, checksum256, &authorized_pub_key_did::by_pk>>
+         > authorized_pub_key_did_table;
 
          struct [[eosio::table("global")]] global_state {
             global_state() { }

--- a/contracts/infra-did-registry/include/infra-did-registry.hpp
+++ b/contracts/infra-did-registry/include/infra-did-registry.hpp
@@ -41,6 +41,35 @@ namespace infra_did {
          void accclearattr( const name& account );
 
          /**
+          * [Account DID] register did as authorized
+          *
+          * @param authorizer
+          * @param account
+          * @param properties
+          */
+         [[eosio::action]]
+         void accauthreg(const name& authorizer, const name& account, const string& properties);
+
+         /**
+          * [Account DID] update properties of authorized did
+          *
+          * @param authorizer
+          * @param account
+          * @param properties
+          */
+         [[eosio::action]]
+         void accauthupdt(const name& authorizer, const name& account, const string& properties);
+
+         /**
+          * [Account DID] deregister did as authorized
+          *
+          * @param authorizer
+          * @param account
+          */
+         [[eosio::action]]
+         void accauthrm(const name& authorizer, const name& account);
+
+         /**
           * [Public Key DID] set attribute for a DID
           *
           * @param pk
@@ -191,6 +220,23 @@ namespace infra_did {
             authorized_pub_key_did,
             indexed_by<"bypk"_n, const_mem_fun<authorized_pub_key_did, checksum256, &authorized_pub_key_did::by_pk>>
          > authorized_pub_key_did_table;
+
+         // authorizer account can add authorized DID in authorized_account_did table with scope as authorizer account name
+         struct [[eosio::table]] authorized_account_did {
+            uint64_t id; // unique identifier
+            name account;
+            string properties; // properties for the DID, stringified JSON
+            
+            uint64_t primary_key() const { return id; }
+            uint64_t by_account() const { return account.value; } // secondary index for account
+
+            EOSLIB_SERIALIZE( authorized_account_did, (id)(account)(properties) )
+         }; 
+
+         typedef eosio::multi_index< "authaccdid"_n, 
+            authorized_account_did,
+            indexed_by<"byaccount"_n, const_mem_fun<authorized_account_did, uint64_t, &authorized_account_did::by_account>>
+         > authorized_account_did_table;
 
          struct [[eosio::table("global")]] global_state {
             global_state() { }

--- a/contracts/infra-did-registry/src/infra-did-registry.cpp
+++ b/contracts/infra-did-registry/src/infra-did-registry.cpp
@@ -212,6 +212,34 @@ void infra_did_registry::pkdidrmvrvkd( const uint64_t pkid ) {
    }
 }
 
+void infra_did_registry::pkaddtrusted(const name& ram_payer, const public_key& pk, const string& metadata){
+   
+   require_auth(ram_payer);
+   trusted_did_table trusted_did_db( get_self(), ram_payer.value );
+   auto pk_index = trusted_did_db.get_index<"bypk"_n>();
+   auto itr_trusted_did_idx = pk_index.find(get_pubkey_index_value(pk));
+
+   check( itr_trusted_did_idx == pk_index.end(), "already registered" );
+
+   trusted_did_db.emplace( ram_payer, [&]( trusted_did& trusted_did ) {
+      trusted_did.id = trusted_did_db.available_primary_key();
+      trusted_did.pk = pk;
+      trusted_did.metadata = metadata;
+   });
+}
+
+void infra_did_registry::pkrmtrusted(const name& ram_payer, const public_key& pk){
+   
+   require_auth(ram_payer);
+   trusted_did_table trusted_did_db( get_self(), ram_payer.value );
+   auto pk_index = trusted_did_db.get_index<"bypk"_n>();
+   auto itr_trusted_did_idx = pk_index.find(get_pubkey_index_value(pk));
+
+   check( itr_trusted_did_idx != pk_index.end(), "not registered" );
+
+   pk_index.erase(itr_trusted_did_idx);
+}
+
 infra_did_registry::pub_key_id_t infra_did_registry::get_pub_key_id_info( const public_key& pk ) {
    pub_key_did_table pk_did_db( get_self(), get_self().value );
    auto pk_index = pk_did_db.get_index<"bypk"_n>();

--- a/contracts/infra-did-registry/src/infra-did-registry.cpp
+++ b/contracts/infra-did-registry/src/infra-did-registry.cpp
@@ -212,32 +212,46 @@ void infra_did_registry::pkdidrmvrvkd( const uint64_t pkid ) {
    }
 }
 
-void infra_did_registry::pkaddtrusted(const name& ram_payer, const public_key& pk, const string& metadata){
+void infra_did_registry::pkauthreg(const name& authorizer, const public_key& pk, const string& properties){
    
-   require_auth(ram_payer);
-   trusted_did_table trusted_did_db( get_self(), ram_payer.value );
-   auto pk_index = trusted_did_db.get_index<"bypk"_n>();
-   auto itr_trusted_did_idx = pk_index.find(get_pubkey_index_value(pk));
+   require_auth(authorizer);
+   authorized_pub_key_did_table authorized_did_db( get_self(), authorizer.value );
+   auto pk_index = authorized_did_db.get_index<"bypk"_n>();
+   auto itr_authorized_did_idx = pk_index.find(get_pubkey_index_value(pk));
 
-   check( itr_trusted_did_idx == pk_index.end(), "already registered" );
+   check( itr_authorized_did_idx == pk_index.end(), "already registered" );
 
-   trusted_did_db.emplace( ram_payer, [&]( trusted_did& trusted_did ) {
-      trusted_did.id = trusted_did_db.available_primary_key();
-      trusted_did.pk = pk;
-      trusted_did.metadata = metadata;
+   authorized_did_db.emplace( authorizer, [&]( authorized_pub_key_did& authorized_did ) {
+      authorized_did.id = authorized_did_db.available_primary_key();
+      authorized_did.pk = pk;
+      authorized_did.properties = properties;
    });
 }
 
-void infra_did_registry::pkrmtrusted(const name& ram_payer, const public_key& pk){
+void infra_did_registry::pkauthupdate(const name& authorizer, const public_key& pk, const string& properties){
    
-   require_auth(ram_payer);
-   trusted_did_table trusted_did_db( get_self(), ram_payer.value );
-   auto pk_index = trusted_did_db.get_index<"bypk"_n>();
-   auto itr_trusted_did_idx = pk_index.find(get_pubkey_index_value(pk));
+   require_auth(authorizer);
+   authorized_pub_key_did_table authorized_did_db( get_self(), authorizer.value );
+   auto pk_index = authorized_did_db.get_index<"bypk"_n>();
+   auto itr_authorized_did_idx = pk_index.find(get_pubkey_index_value(pk));
 
-   check( itr_trusted_did_idx != pk_index.end(), "not registered" );
+   check( itr_authorized_did_idx != pk_index.end(), "not registered" );
 
-   pk_index.erase(itr_trusted_did_idx);
+   pk_index.modify( itr_authorized_did_idx, same_payer, [&]( authorized_pub_key_did& authorized_did ) {
+      authorized_did.properties = properties;
+   });
+}
+
+void infra_did_registry::pkauthremove(const name& authorizer, const public_key& pk){
+   
+   require_auth(authorizer);
+   authorized_pub_key_did_table authorized_did_db( get_self(), authorizer.value );
+   auto pk_index = authorized_did_db.get_index<"bypk"_n>();
+   auto itr_authorized_did_idx = pk_index.find(get_pubkey_index_value(pk));
+
+   check( itr_authorized_did_idx != pk_index.end(), "not registered" );
+
+   pk_index.erase(itr_authorized_did_idx);
 }
 
 infra_did_registry::pub_key_id_t infra_did_registry::get_pub_key_id_info( const public_key& pk ) {

--- a/contracts/infra-did-registry/src/infra-did-registry.cpp
+++ b/contracts/infra-did-registry/src/infra-did-registry.cpp
@@ -42,6 +42,48 @@ void infra_did_registry::accclearattr( const name& account ) {
    }
 }
 
+void infra_did_registry::accauthreg(const name& authorizer, const name& account, const string& properties){
+   
+   require_auth(authorizer);
+   authorized_account_did_table authorized_did_db( get_self(), authorizer.value );
+   auto pk_index = authorized_did_db.get_index<"byaccount"_n>();
+   auto itr_authorized_did_idx = pk_index.find(account.value);
+
+   check( itr_authorized_did_idx == pk_index.end(), "already registered" );
+
+   authorized_did_db.emplace( authorizer, [&]( authorized_account_did& authorized_did ) {
+      authorized_did.id = authorized_did_db.available_primary_key();
+      authorized_did.account = account;
+      authorized_did.properties = properties;
+   });
+}
+
+void infra_did_registry::accauthupdt(const name& authorizer, const name& account, const string& properties){
+   
+   require_auth(authorizer);
+   authorized_account_did_table authorized_did_db( get_self(), authorizer.value );
+   auto pk_index = authorized_did_db.get_index<"byaccount"_n>();
+   auto itr_authorized_did_idx = pk_index.find(account.value);
+
+   check( itr_authorized_did_idx != pk_index.end(), "not registered" );
+
+   pk_index.modify( itr_authorized_did_idx, same_payer, [&]( authorized_account_did& authorized_did ) {
+      authorized_did.properties = properties;
+   });
+}
+
+void infra_did_registry::accauthrm(const name& authorizer, const name& account){
+   
+   require_auth(authorizer);
+   authorized_account_did_table authorized_did_db( get_self(), authorizer.value );
+   auto pk_index = authorized_did_db.get_index<"byaccount"_n>();
+   auto itr_authorized_did_idx = pk_index.find(account.value);
+
+   check( itr_authorized_did_idx != pk_index.end(), "not registered" );
+
+   pk_index.erase(itr_authorized_did_idx);
+}
+
 void infra_did_registry::pksetattr( const public_key& pk, const string& key, const string& value, const signature& sig, const name& ram_payer ) {
 
    check(pk.index() <= 1, "not supported public key type" );


### PR DESCRIPTION
## Implement issuer and verifier registry

* add `authpkdid`, `authaccdid` table
* add `pkauthreg`, `pkauthupdate`, `pkauthremove`, `accauthreg`, `accauthupdt`, `accauthrm` action 

This PR implement action to add / remove did to trusted did.  Users can verify which DIDs someone trusts as issuer or verifier.